### PR TITLE
Minor, necessary adjustments

### DIFF
--- a/M1_Sample_Code/3_pdf_rag/3_rag_chain_driver_notebook.py
+++ b/M1_Sample_Code/3_pdf_rag/3_rag_chain_driver_notebook.py
@@ -34,6 +34,10 @@ dbutils.library.restartPython()
 
 # COMMAND ----------
 
+# MAGIC %run ../RAG_Experimental_Code
+
+# COMMAND ----------
+
 import json
 import os
 
@@ -63,10 +67,6 @@ def parse_deployment_info(deployment_info):
   Review App: {deployment_info.rag_app_url}"""
   return message
 ### END: Ignore this code, temporary workarounds given the Private Preview state of the product
-
-# COMMAND ----------
-
-# MAGIC %run ../RAG_Experimental_Code
 
 # COMMAND ----------
 

--- a/M1_Sample_Code/4_rag_chain_w_conversation_history /4_rag_chain_w_conversation_history_driver_notebook.py
+++ b/M1_Sample_Code/4_rag_chain_w_conversation_history /4_rag_chain_w_conversation_history_driver_notebook.py
@@ -34,6 +34,10 @@ dbutils.library.restartPython()
 
 # COMMAND ----------
 
+# MAGIC %run ../RAG_Experimental_Code
+
+# COMMAND ----------
+
 import json
 import os
 
@@ -63,10 +67,6 @@ def parse_deployment_info(deployment_info):
   Review App: {deployment_info.rag_app_url}"""
   return message
 ### END: Ignore this code, temporary workarounds given the Private Preview state of the product
-
-# COMMAND ----------
-
-# MAGIC %run ../RAG_Experimental_Code
 
 # COMMAND ----------
 

--- a/M1_Sample_Code/RAG_Experimental_Code.py
+++ b/M1_Sample_Code/RAG_Experimental_Code.py
@@ -9,7 +9,7 @@
 # COMMAND ----------
 
 # DBTITLE 1,Get Trace from Chain
-from databricks.rag.scoring import predictions as rag
+from databricks.rag.scoring import predictions
 from databricks import rag_eval
 
 def _convert_trace_buffer_to_trace_object(trace_buffer):
@@ -23,15 +23,15 @@ def _convert_trace_buffer_to_trace_object(trace_buffer):
     else:
         start_timestamp = trace_buffer[0].start_timestamp
         end_timestamp = trace_buffer[-1].end_timestamp
-    return rag.Trace(
+    return predictions.Trace(
         steps=trace_buffer,
         start_timestamp=start_timestamp,
         end_timestamp=end_timestamp,
     )
 
 def experimental_get_json_trace(langchain_model, model_input):
-  handler = rag.DatabricksChainCallback()
-  langchain_wrapped_model = rag._LangChainModelWrapper(langchain_model)
+  handler = predictions.DatabricksChainCallback()
+  langchain_wrapped_model = predictions._LangChainModelWrapper(langchain_model)
   # noinspection PyTypeChecker
   model_output: dict = langchain_wrapped_model._predict_with_callbacks(
       model_input, callback_handlers=[handler], convert_chat_responses=True


### PR DESCRIPTION
RAG_Experimental_Code.py needed to have "rag" from databricks library renamed to avoid conflicts in notebooks selected. Tutorials 3 and 4 needed the command to run RAG_Experimental_Code.py moved to ensure rest of notebook worked correctly.